### PR TITLE
Update ndt7-upload-worker.js

### DIFF
--- a/src/ndt7-upload-worker.js
+++ b/src/ndt7-upload-worker.js
@@ -16,7 +16,7 @@ const workerMain = function(ev) {
   let now = () => new Date().getTime();
   if (typeof performance !== 'undefined' &&
       typeof performance.now !== 'undefined') {
-    now = performance.now;
+    now = () => performance.now();
   }
   uploadTest(sock, postMessage, now);
 };


### PR DESCRIPTION
a = performance.now
a()
causes an error in the browsers (firefox, chrome)
" 'now' called on an object that does not implement interface Performance "